### PR TITLE
Add study mode and session tracking

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -4,7 +4,7 @@
 
 - clsx
 - markdown-it
-- highlight.js (*gruvbox-dark-soft.min theme*)
+- highlight.js (*atom-one-light theme*)
 - @mdit/plugin-katex
 - react-router
 - jotai

--- a/api/deck-store/create_table.sh
+++ b/api/deck-store/create_table.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Get the directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pnpx wrangler d1 execute remain-decks --file "$SCRIPT_DIR/sql_tables/deck_table.sql" --local
+pnpx wrangler d1 execute remain-decks --file "$SCRIPT_DIR/sql_tables/study_session.sql" --local

--- a/api/deck-store/sql_tables/deck_table.sql
+++ b/api/deck-store/sql_tables/deck_table.sql
@@ -1,0 +1,10 @@
+CREATE IF NOT EXISTS TABLE deck (
+    deckid TEXT PRIMARY KEY, -- GUID
+    title TEXT NOT NULL,
+    length INTEGER,
+    updated DATETIME DEFAULT CURRENT_TIMESTAMP,
+    created DATETIME DEFAULT CURRENT_TIMESTAMP,
+    delete_date DATETIME DEFAULT NULL,
+    last_session DATETIME DEFAULT NULL,
+    score REAL CHECK (score >= 0 AND score <= 100) DEFAULT NULL
+);

--- a/api/deck-store/sql_tables/study_session.sql
+++ b/api/deck-store/sql_tables/study_session.sql
@@ -1,0 +1,11 @@
+CREATE IF NOT EXISTS TABLE study_session (
+    session_id TEXT PRIMARY KEY, -- GUID
+    deckid TEXT NOT NULL,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+    correct_count INTEGER NOT NULL DEFAULT 0,
+    incorrect_count INTEGER NOT NULL DEFAULT 0,
+    wrong_answers_indexes TEXT, -- JSON array of card indexes (e.g., "[1, 5, 12]")
+    FOREIGN KEY (deckid) REFERENCES deck(deckid) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_study_session_deckid ON study_session(deckid);

--- a/api/deck-store/src/index.ts
+++ b/api/deck-store/src/index.ts
@@ -1,9 +1,11 @@
-import { Hono } from "hono";
+import { Context, Hono } from "hono";
+import { studySession } from "./study_session";
 import { cors } from "hono/cors";
-import { R2Bucket } from "@cloudflare/workers-types";
+import { D1Database, R2Bucket } from "@cloudflare/workers-types";
 
 type Bindings = {
   DECK_BUCKET: R2Bucket;
+  DECKS_DB: D1Database;
 };
 
 const deck = new Hono<{ Bindings: Bindings }>();
@@ -17,9 +19,9 @@ deck.get("/:deckid", async (c) => {
   if (content !== undefined) return c.json(content);
 
   return c.json([]);
-
 }).put(async (c) => {
   const body = await c.req.json();
+  const deckid = c.req.param("deckid");
 
   if (body == "") {
     c.status(400);
@@ -28,25 +30,49 @@ deck.get("/:deckid", async (c) => {
     });
   }
 
+  const length = body.cards?.length || 0;
+
+  await c.env.DECKS_DB.prepare(`
+  INSERT INTO deck (deckid, title, length)
+  VALUES (?, ?, ?)
+  ON CONFLICT(deckid) DO UPDATE SET
+    title = excluded.title,
+    length = excluded.length,
+    updated = datetime('now')
+  `).bind(deckid, body.title, length).run();
+
   await c.env.DECK_BUCKET.put(
-    c.req.param("deckid"),
+    deckid,
     JSON.stringify(body),
     {
       customMetadata: {
-        title: body.title
-      }
-    }
+        title: body.title,
+        length: length,
+      },
+    },
   );
 
   return c.json({
     error: null,
-    url: `/deck/${c.req.param("deckid")}`,
+    url: `/deck/${deckid}`,
   });
-
-
 }).delete(async (c) => {
+  const hard = c.req.query("hard");
   try {
-    await c.env.DECK_BUCKET.delete(c.req.param("deckid"));
+    if (hard === "true") {
+      await c.env.DECK_BUCKET.delete(c.req.param("deckid"));
+      await c.env.DECKS_DB.prepare(`
+      DELETE FROM deck WHERE deckid = ?
+    `).bind(c.req.param("deckid")).run();
+    } else {
+      await c.env.DECKS_DB.prepare(`
+        UPDATE deck 
+        SET delete_date = datetime('now'),
+            updated = datetime('now')
+        WHERE deckid = ? AND delete_date IS NULL
+      `).bind(c.req.param("deckid")).run();
+    }
+
     return c.json({
       error: null,
     });
@@ -57,21 +83,43 @@ deck.get("/:deckid", async (c) => {
   }
 });
 
-app.get("/decks", async (c) => {
-  const decks = await c.env.DECK_BUCKET.list({
-    limit: 15,
-    include: ['customMetadata']
-  });
+const listDecksHandler = async (c: Context<{ Bindings: Bindings }>) => {
+  try {
+    const { results } = await c.env.DECKS_DB.prepare(`
+      SELECT deckid, title, length, created, last_session, score
+      FROM deck
+      WHERE delete_date IS NULL
+      ORDER BY created DESC
+      LIMIT 15
+    `).all();
 
-  return c.json({
-    error: null,
-    decks: decks.objects
-  });
-});
+    return c.json({
+      error: null,
+      decks: results.map((deck: any) => ({
+        key: deck.deckid,
+        uploaded: deck.created,
+        title: deck.title,
+        length: deck.length,
+        last_session: deck.last_session,
+        score: deck.score,
+      })),
+    });
+  } catch (e: any) {
+    console.error("Error listing decks:", e);
+    return c.json({
+      error: e.message || "Failed to list decks",
+      decks: [],
+    });
+  }
+}
 
+app.get("/decks", listDecksHandler);
+app.get("/api/v1/decks", listDecksHandler);
 
 app.route("deck", deck);
 app.route("api/v1/deck", deck);
 
+app.route("/study_session", studySession);
+app.route("api/v1/study_session", studySession);
 
 export default app;

--- a/api/deck-store/src/study_session.ts
+++ b/api/deck-store/src/study_session.ts
@@ -1,0 +1,86 @@
+import { Hono } from "hono";
+import { D1Database } from "@cloudflare/workers-types";
+
+type Bindings = {
+  DECKS_DB: D1Database;
+};
+
+const studySession = new Hono<{ Bindings: Bindings }>();
+
+studySession.post(
+  "/:deckid",
+  async (c) => {
+    const deckid = c.req.param("deckid");
+    const {
+      correct_count,
+      incorrect_count,
+      wrong_answers_indexes,
+      session_id,
+    } = await c.req.json();
+
+    console.log(deckid, correct_count, incorrect_count, wrong_answers_indexes, session_id);
+
+    const totalCards = (correct_count ?? 0) + (incorrect_count ?? 0);
+    const sessionScore = totalCards > 0 ? ((correct_count ?? 0) * 100) / totalCards : 0;
+
+    try {
+      await c.env.DECKS_DB.batch([
+        c.env.DECKS_DB.prepare(`
+          INSERT INTO study_session (session_id, deckid, correct_count, incorrect_count, wrong_answers_indexes)
+          VALUES (?, ?, ?, ?, ?)
+        `).bind(
+          session_id,
+          deckid,
+          correct_count ?? 0,
+          incorrect_count ?? 0,
+          wrong_answers_indexes ? JSON.stringify(wrong_answers_indexes) : "[]",
+        ),
+        c.env.DECKS_DB.prepare(`
+          UPDATE deck 
+          SET score = 
+          CASE 
+              WHEN score IS NULL THEN ? 
+              ELSE (score + ?) / 2.0 
+          END,
+          last_session = datetime('now')
+          WHERE deckid = ?
+        `).bind(sessionScore, sessionScore, deckid)
+      ]);
+
+      return c.json({
+        error: null,
+        session_id,
+      });
+    } catch (e: any) {
+      console.error(e);
+      c.status(500);
+      return c.json({
+        error: e.message || "Failed to save study session",
+      });
+    }
+  },
+).get("/:deckid", async (c) => {
+  const deckid = c.req.param("deckid");
+  try {
+    const { results } = await c.env.DECKS_DB.prepare(`
+      SELECT * FROM study_session WHERE deckid = ? ORDER BY timestamp DESC
+    `).bind(deckid).all();
+
+    return c.json({
+      error: null,
+      sessions: results.map((r) => ({
+        ...r,
+        wrong_answers_indexes: r.wrong_answers_indexes
+          ? JSON.parse(r.wrong_answers_indexes as string)
+          : [],
+      })),
+    });
+  } catch (e: any) {
+    c.status(500);
+    return c.json({
+      error: e.message || "Failed to fetch study sessions",
+    });
+  }
+});
+
+export { studySession };

--- a/api/deck-store/wrangler.jsonc
+++ b/api/deck-store/wrangler.jsonc
@@ -1,38 +1,64 @@
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "deck-store",
-  "main": "src/index.ts",
-  "compatibility_date": "2026-01-20",
-  // "compatibility_flags": [
-  //   "nodejs_compat"
-  // ],
-  // "vars": {
-  //   "MY_VAR": "my-variable"
-  // },
-  // "kv_namespaces": [
-  //   {
-  //     "binding": "MY_KV_NAMESPACE",
-  //     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-  //   }
-  // ],
-  "r2_buckets": [
-    {
-      "binding": "DECK_BUCKET",
-      "bucket_name": "remain-decks",
-    }
-  ],
-  // "d1_databases": [
-  //   {
-  //     "binding": "MY_DB",
-  //     "database_name": "my-database",
-  //     "database_id": ""
-  //   }
-  // ],
-  // "ai": {
-  //   "binding": "AI"
-  // },
-  // "observability": {
-  //   "enabled": true,
-  //   "head_sampling_rate": 1
-  // }
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "deck-store",
+	"main": "src/index.ts",
+	"compatibility_date": "2026-01-20",
+	// "compatibility_flags": [
+	//   "nodejs_compat"
+	// ],
+	// "vars": {
+	//   "MY_VAR": "my-variable"
+	// },
+	// "kv_namespaces": [
+	//   {
+	//     "binding": "MY_KV_NAMESPACE",
+	//     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	//   }
+	// ],
+	"r2_buckets": [
+		{
+			"binding": "DECK_BUCKET",
+			"bucket_name": "remain-decks",
+		}
+	],
+	"d1_databases": [
+		{
+			"binding": "DECKS_DB",
+			"database_name": "remain-decks",
+			"database_id": "db97cee3-e88d-43c0-8ebc-53743c286174",
+			// "remote": true
+		},
+	],
+	// "d1_databases": [
+	//   {
+	//     "binding": "DECKS",
+	//     "database_name": "decks",
+	//     "database_id": "decks"
+	//   },
+	// ],
+	// "durable_objects": {
+	//   "bindings": [
+	//     {
+	//       "name": "STUDY_SESS_DO",
+	//       "class_name": "StudySessionDO"
+	//     }
+	//   ]
+	// },
+	// "migrations": [
+	//   {
+	//     "tag": "v1", // Should be unique for each entry
+	//     "new_classes": [
+	//       // Array of new classes
+	//       "MyDurableObject",
+	//     ],
+	//   },
+	// ],
+	// ],
+	// "ai": {
+	//   "binding": "AI"
+	// },
+	// "observability": {
+	//   "enabled": true,
+	//   "head_sampling_rate": 1
+	// }
 }

--- a/api/query_db.sh
+++ b/api/query_db.sh
@@ -1,0 +1,2 @@
+pnpx wrangler d1 execute remain-decks --local --command "select * from study_session"
+pnpx wrangler d1 execute remain-decks --local --command "select * from deck"

--- a/app/app.css
+++ b/app/app.css
@@ -9,6 +9,19 @@
   --font-mono:
     "IBM Plex Mono", SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
     "Courier New", monospace;
+
+
+  --animate-fast-spin: fast-spin 2s ease-in-out infinite;
+
+  @keyframes fast-spin {
+    0% {
+      transform: rotate(0deg);
+    }
+
+    100% {
+      transform: rotate(1800deg);
+    }
+  }
 }
 
 html,
@@ -148,6 +161,8 @@ body {
   pre {
     @apply my-8 px-4 py-4 rounded-xl overflow-x-auto leading-5 whitespace-pre text-left;
   }
+
+
 }
 
 
@@ -178,3 +193,7 @@ body {
 .scrollbar-thin::-webkit-scrollbar-thumb:hover {
   background-color: rgba(115, 115, 130, 0.8);
 }
+
+/* .katex-mathml {
+  visibility: hidden;
+} */

--- a/app/lib/my-components/CardEditor.tsx
+++ b/app/lib/my-components/CardEditor.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect } from "react";
 import { X, Check } from "lucide-react";
 import { MarkdownRenderer } from "~/lib/utils/MarkdownRenderer";
-import '~/styles/gruvbox-dark-soft.min.css';
+import '~/styles/atom-one-light.css';
 
 
 interface CardEditorProps {

--- a/app/lib/my-components/CardPreview.tsx
+++ b/app/lib/my-components/CardPreview.tsx
@@ -15,7 +15,6 @@ export const CardPreview: React.FC<CardPreviewProps> = ({ cards, previewIndex, o
 
     const [mdFront, mdBack] = useMemo(() => {
         const mdRenderer = new MarkdownRenderer();
-        // console.log(card.back);
         return [
             mdRenderer.render(card.front),
             mdRenderer.render(card.back),
@@ -44,7 +43,7 @@ export const CardPreview: React.FC<CardPreviewProps> = ({ cards, previewIndex, o
                     {/* {card.front} */}
                 </div>
                 <hr />
-                <div className=" text-sm overflow-x-auto" dangerouslySetInnerHTML={{ __html: mdBack }}>
+                <div className=" text-sm overflow-x-auto overflow-hidden" dangerouslySetInnerHTML={{ __html: mdBack }}>
                     {/* {card.back} */}
                 </div>
             </div>

--- a/app/lib/my-components/DeckCarousel.tsx
+++ b/app/lib/my-components/DeckCarousel.tsx
@@ -55,7 +55,7 @@ export default function DeckCarousel({ cards, onClose }: DeckCarouselProps) {
                             <div className="text-center">
                                 <div className="text-lg" dangerouslySetInnerHTML={{ __html: mdRenderer.render(card.front) }}></div>
                             </div>
-                            <div className="text-center border-t pt-4 overflow-x-auto max-w-full scrollbar-thin">
+                            <div className="text-center border-t pt-4 overflow-x-auto overflow-hidden max-w-full scrollbar-thin">
                                 <div className="text-md text-gray-700" dangerouslySetInnerHTML={{ __html: mdRenderer.render(card.back) }}></div>
                             </div>
                         </div>

--- a/app/lib/my-components/DeckPreview.tsx
+++ b/app/lib/my-components/DeckPreview.tsx
@@ -5,7 +5,7 @@ import { CardPreview } from '~/lib/my-components/CardPreview';
 import { deckDraftAtom } from '~/lib/state/deckDraft';
 import { MarkdownRenderer } from '~/lib/utils/MarkdownRenderer';
 import CardEditor from '~/lib/my-components/CardEditor';
-import '~/styles/gruvbox-dark-soft.min.css';
+import '~/styles/atom-one-light.css';
 
 
 interface DeckPreviewProps {

--- a/app/lib/my-components/SavedDecks.tsx
+++ b/app/lib/my-components/SavedDecks.tsx
@@ -4,25 +4,27 @@ import { calculateTemporalDiff } from "../utils/calculateTemporalDiff";
 
 interface SavedDecksProps {
     savedDecks: SavedDeck[];
+    className?: string
 }
 
 
 
-export function SavedDecks({ savedDecks }: SavedDecksProps) {
+export function SavedDecks({ savedDecks, className }: SavedDecksProps) {
     return (
-        <ul>
+        <ul className={className}>
             {savedDecks?.map((deck) => {
-                return (<li key={deck.id} className={`
-                    my-1 text-gray-600 hover:text-gray-900 truncate
-                `}>
-                    <Link to={deck.url} viewTransition className={clsx(
-                        "after:text-gray-900",
-                        // "after:ml-0.5"
-                    )}>
-                        {deck.title}
-                        <span className="text-xs tracking-tighter ml-3 text-gray-400">{calculateTemporalDiff(new Date(deck.uploaded))} days ago</span>
-                    </Link>
-                </li>)
+                return (
+                    <li key={deck.id} className={`
+                        my-3 text-gray-600 hover:text-gray-900 truncate
+                    `}>
+                        <Link to={deck.url} viewTransition className={clsx(
+                            "after:text-gray-900",
+                            // "after:ml-0.5"
+                        )}>
+                            {deck.title}
+                            <span className="text-xs tracking-tighter ml-3 text-gray-400">{calculateTemporalDiff(new Date(deck.uploaded))} days ago</span>
+                        </Link>
+                    </li>)
             })}
         </ul>
     )

--- a/app/lib/types/types.d.ts
+++ b/app/lib/types/types.d.ts
@@ -14,8 +14,12 @@ interface Message {
 }
 
 interface SavedDeck {
+  key: string;
   title: string;
-  url: string
-  id: string,
-  uploaded: string
+  url: string;
+  id: string;
+  uploaded: Date;
+  length: number;
+  score: number;
+  last_session: string;
 }

--- a/app/lib/utils/calculateTemporalDiff.ts
+++ b/app/lib/utils/calculateTemporalDiff.ts
@@ -1,8 +1,8 @@
 export function calculateTemporalDiff(datetime: Date): number {
     const now = new Date();
-    const diffInMs = datetime.getTime() - now.getTime();
+    const diffInMs = now.getTime() - datetime.getTime();
 
-    const diffInDays = Math.ceil(diffInMs / (1000 * 60 * 60 * 24));
+    const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
 
     return diffInDays;
 }

--- a/app/lib/utils/calculateTemporalDiffHours.ts
+++ b/app/lib/utils/calculateTemporalDiffHours.ts
@@ -1,0 +1,13 @@
+export function calculateTemporalDiffHours(datetime: Date): number {
+    const now = new Date();
+    datetime.setHours(datetime.getHours() - (new Date().getTimezoneOffset() / 60));
+    const diffInMs = (now.getTime()) - datetime.getTime();
+
+    const diffInHours = Math.ceil(diffInMs / (1000 * 60 * 60));
+    // console.log('diff', diffInHours);
+
+    // console.log('date', datetime);
+    if (datetime.getFullYear() === 1969) return 0;
+
+    return diffInHours;
+}

--- a/app/lib/utils/getScoreStyle.ts
+++ b/app/lib/utils/getScoreStyle.ts
@@ -1,0 +1,6 @@
+export const getScoreStyle = (score: number = 0) => {
+    const percentage = Math.min(Math.max(score, 0), 100);
+    return {
+        color: `color-mix(in oklab,var(--color-red-400),var(--color-green-500) ${percentage}%)`
+    };
+};

--- a/app/routes/decks.tsx
+++ b/app/routes/decks.tsx
@@ -1,0 +1,121 @@
+import type { Route } from "./+types/decks";
+import { useThrottle } from "@uidotdev/usehooks";
+import clsx from "clsx";
+import { BookA, PanelRight, Search } from "lucide-react";
+import { useCallback, useState } from "react";
+import { Link } from "react-router";
+import { calculateTemporalDiff } from "~/lib/utils/calculateTemporalDiff";
+import { calculateTemporalDiffHours } from "~/lib/utils/calculateTemporalDiffHours";
+import { getScoreStyle } from "~/lib/utils/getScoreStyle";
+
+
+const API_BASE = process.env.API_BASE_URL || '';
+
+
+//  "decks": [
+//     {
+//       "key": "9516268f-a6b9-44a0-92c3-a88b782e64b1",
+//       "uploaded": "2026-02-04 06:55:53",
+//       "title": "Life and death about the great Simon Bolivar",
+//       "length": 12,
+//       "last_session": "2026-02-04 07:24:03",
+//       "score": 25
+//     },
+
+export async function loader() {
+    const savedDecks = (
+        await (await fetch(`${API_BASE}/api/v1/decks`)).json()
+    ).decks.filter((deck: any) =>
+        !!(deck?.title)
+    )?.map((deck: any) => ({
+        ...deck,
+        id: deck.key,
+        url: `/study/${deck.key}`,
+        uploaded: new Date(deck.uploaded),
+    }));
+
+    return {
+        decks: savedDecks,
+    }
+}
+
+
+export default function Decks({ loaderData }: Route.ComponentProps) {
+    const [searchTerm, setSearchTerm] = useState("");
+    const throttleSearchTerm = useThrottle(searchTerm, 400);
+    const handleOnChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        setSearchTerm(e.target.value);
+    }, [setSearchTerm])
+    return (
+        <div className="mt-3 px-1">
+            <div className="flex items-center justify-between mx-3 mb-8">
+                <h1 className="text-2xl font-bold text-gray-400">Decks</h1>
+                <PanelRight className="text-gray-400" />
+            </div>
+            <div className="flex items-center justify-center mb-3">
+                <input type="text" id="search-deck" className={`
+                    text-base border-2 py-1 px-2 rounded-md border-gray-200 transition-colors
+                        focus:outline-none focus:border-gray-400 w-[80%] mr-1 mb-2
+                `} onChange={handleOnChange} />
+                <Search className="text-gray-400" />
+            </div>
+            <ul className="flex flex-col gap-5 mb-4">
+                {
+                    loaderData.decks
+                        .filter(
+                            (item: SavedDeck) => item.title.toLowerCase().includes(throttleSearchTerm.toLowerCase())
+                        ).map((deck: SavedDeck) => {
+                            return (
+                                <li key={deck.id} className={`
+                                    my-1 text-gray-600 hover:text-gray-900 truncate
+                                    py-1 px-2 mx-1 border-b border-b-gray-100 pb-3
+                                `}>
+                                    <span className={clsx(
+                                        "after:text-gray-900",
+                                        "w-full",
+                                    )}>
+                                        <span className="flex items-center justify-between">
+                                            <Link to={deck.url} className="flex items-center max-w-[80%]" viewTransition>
+                                                <BookA size={16} className="inline-block mr-1 shrink-0" />
+                                                <span className="truncate">
+                                                    {deck.title}
+                                                </span>
+                                            </Link>
+                                            <span>
+                                                <Link to={`/generate/${deck.id}`} viewTransition
+                                                    className="text-sm items-center text-gray-400 underline text-right font-light">
+                                                    {/* <Pencil className="inline" size={14}/> */}
+                                                    Edit
+                                                </Link>
+                                            </span>
+                                        </span>
+                                        <span className="text-sm flex justify-between">
+                                            <span className="font-light text-gray-400">
+                                                {deck.length} cards
+                                            </span>
+                                            <span className={`text-xs font-bold`} style={getScoreStyle(deck.score)}>
+                                                {deck.score?.toFixed(2)}
+                                            </span>
+                                        </span>
+                                        <span className="text-xs tracking-tighter text-gray-400 align-middle flex justify-between font-light">
+                                            {
+                                                calculateTemporalDiff(new Date(deck.uploaded)) > 0 ?
+                                                    `Created ${calculateTemporalDiff(new Date(deck.uploaded))} days ago` :
+                                                    `Created today`
+                                            }
+                                            <span>
+                                                {
+                                                    calculateTemporalDiffHours(new Date(deck.last_session)) > 0 ?
+                                                        `${calculateTemporalDiffHours(new Date(deck.last_session))} hours since last session` :
+                                                        "never studied"
+                                                }
+                                            </span>
+                                        </span>
+                                    </span>
+                                </li>
+                            )
+                        })}
+            </ul>
+        </div>
+    );
+}

--- a/app/routes/generate.$chatId.tsx
+++ b/app/routes/generate.$chatId.tsx
@@ -1,4 +1,4 @@
-import { useFetcher, type ShouldRevalidateFunctionArgs } from "react-router";
+import { useFetcher } from "react-router";
 import { Paperclip, SendHorizontal, File } from "lucide-react";
 import type { Route } from "./+types/generate.$chatId";
 import { ChatHistory } from "~/lib/my-components/ChatHistory";
@@ -7,6 +7,7 @@ import { useAtom, useSetAtom } from "jotai";
 import { useCallback, useEffect, useRef, useState, type ChangeEvent } from "react";
 import { getAgentCompletion } from "~/lib/agents/deckGenerationAgent";
 import { deckDraftAtom } from "~/lib/state/deckDraft";
+import clsx from "clsx";
 
 
 
@@ -149,6 +150,12 @@ export default function GenerateChatId({
                 <ChatHistory messages={chatHistory} />
             </div>
             <div className="pb-12 w-full flex flex-col items-center">
+                <div className="h-8 flex flex-col items-center justify-center">
+                    <div className={clsx(
+                        "size-4 bg-gray-800 rounded-[4px] transition-all animate-fast-spin",
+                        fetcher.state === 'submitting' ? 'opacity-100 scale-100' : 'opacity-0 scale-0'
+                    )} id="spinner"></div>
+                </div>
                 <fetcher.Form className={`${fetcher.state === 'submitting' && 'animate-pulse'} has-focus:shadow-lg has-focus:scale-[1.01] transition-all rounded-md ease-in-out duration-200 w-[calc(12/13*100%)] flex flex-col items-stretch focus:border-gray-400 focus:border-2 focus:border-solid`} method="post" encType="multipart/form-data">
                     <textarea
                         value={prompt}

--- a/app/routes/generate.tsx
+++ b/app/routes/generate.tsx
@@ -37,9 +37,9 @@ export async function loader({ params }: Route.LoaderArgs) {
     const savedDecks = (
         await (await fetch(`${API_BASE}/api/v1/decks`)).json()
     ).decks.filter((deck: any) =>
-        !!(deck?.customMetadata?.title)
+        !!(deck?.title)
     )?.map((deck: any) => ({
-        title: deck.customMetadata.title,
+        title: deck.title,
         id: deck.key,
         url: `/generate/${deck.key}`,
         uploaded: new Date(deck.uploaded),
@@ -133,7 +133,7 @@ export default function Generate({
                 <Outlet />
             </div>
             <div className="-col-start-2 px-3 pb-2 bg-gray-50 overflow-y-auto overflow-x-clip scrollbar-thin relative">
-                <div className='sticky top-0 py-4 inline-flex justify-start items-center bg-gray-50 w-full' >
+                <div className='sticky top-0 py-4 inline-flex justify-start items-center bg-gray-50 w-full z-20' >
                     <h2 className="text-xl hover:cursor-pointer" onClick={() => setShowDeckCarousel(true)}>Deck <ScanEye className='inline size-6 hover:cursor-pointer text-gray-600' /></h2>
                     <div className="flex justify-center items-center ml-auto h-full">
                         {showToast && <ToastNotification message="Deck saved" isVisible={showToast} onClose={() => setShowToast(false)} />}

--- a/app/routes/study.$deckId.tsx
+++ b/app/routes/study.$deckId.tsx
@@ -1,0 +1,163 @@
+import { getDeckById } from "~/lib/utils/getDeckById";
+import type { Route } from "./+types/study.$deckId";
+import { useEffect, useMemo, useState, useRef } from "react";
+import { MarkdownRenderer } from "~/lib/utils/MarkdownRenderer";
+import { ArrowLeft, Plus, RotateCcw } from "lucide-react";
+import '~/styles/atom-one-light.css';
+import { Link, useRevalidator } from "react-router";
+import clsx from "clsx";
+
+
+// const API_BASE = process.env.API_BASE_URL || '';
+
+
+export async function loader({ params }: Route.LoaderArgs) {
+    const deck = await getDeckById(params.deckId);
+
+    return {
+        deck,
+        deckId: params.deckId,
+        sessionId: crypto.randomUUID(),
+    }
+}
+
+export const links: Route.LinksFunction = () => [
+    {
+        rel: "stylesheet",
+        href: "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css",
+        integrity: "sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP",
+        crossOrigin: "anonymous"
+    },
+];
+
+
+export default function Study({
+    loaderData
+}: Route.ComponentProps) {
+    const [cardIndex, setCardIndex] = useState(0);
+    const revalidator = useRevalidator();
+
+
+    const [showBack, setShowBack] = useState(false);
+    const [results, setResults] = useState({
+        right: 0,
+        wrong: 0,
+        passed: 0,
+        wrongIndexes: [] as number[],
+    });
+
+
+    const handleRestart = () => {
+        setResults({
+            right: 0,
+            wrong: 0,
+            passed: 0,
+            wrongIndexes: [],
+        });
+        setShowBack(false);
+        setCardIndex(0);
+        revalidator.revalidate();
+    };
+
+    const card = loaderData.deck.cards[cardIndex];
+    const [mdFront, mdBack] = useMemo(() => {
+        const mdRenderer = new MarkdownRenderer();
+        return [
+            mdRenderer.render(card?.front || ''),
+            mdRenderer.render(card?.back || ''),
+        ];
+    }, [card]);
+
+
+    useEffect(() => {
+        const isFinished = cardIndex === loaderData.deck.cards.length;
+        if (isFinished && loaderData.deck.cards.length > 0) {
+            const res = fetch(`${"http://192.168.1.108:8787"}/api/v1/study_session/${loaderData.deckId}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    correct_count: results.right,
+                    incorrect_count: results.wrong,
+                    wrong_answers_indexes: results.wrongIndexes,
+                    session_id: loaderData.sessionId
+                }),
+            })
+            .catch(err => console.error("Failed to sync study session:", err))
+            .then((r) => r?.json()).then(console.log);
+        }
+    }, [cardIndex, loaderData.deck.cards.length, loaderData.deckId, results]);
+
+
+    return (
+        <div className="fixed inset-0 grid grid-cols-1 grid-rows-7 gap-4 z-50 px-2">
+            <div className="row-span-1 mt-4 flex justify-between">
+                <Link to="/decks" viewTransition className={clsx({
+                    "opacity-0": cardIndex === loaderData.deck.cards.length
+                })}>
+                    <ArrowLeft />
+                </Link>
+                <span className="text-gray-400 truncate inline-block px-3">{loaderData.deck.title}</span>
+                <RotateCcw onClick={handleRestart} className={clsx({
+                    "opacity-0": cardIndex === loaderData.deck.cards.length
+                })} />
+            </div>
+            <div className="row-start-2 row-span-5 flex flex-col gap-6">
+                {cardIndex < loaderData.deck.cards.length && <>
+                    <div className="text-lg wrap-normal bg-white p-4 rounded-md  shadow-gray-100 relative w-full" dangerouslySetInnerHTML={{ __html: mdFront }}>
+                    </div>
+                    {showBack &&
+                        <div className="text-base overflow-x-auto align-middle overflow-hidden bg-white p-4 rounded-md  shadow-gray-100 relative max-w-md w-full"
+                            dangerouslySetInnerHTML={{ __html: mdBack }}
+                        >
+                        </div>
+                    }
+                </>}
+                {cardIndex === loaderData.deck.cards.length &&
+                    <div className="flex flex-col items-center gap-8">
+                        <Link to="/decks" viewTransition className="flex-inline justify-center items-center flex-row bg-gray-100 text-gray-700 px-4 py-2 rounded-md">
+                            <ArrowLeft className="inline" size={14} /> Go back to decks
+                        </Link>
+                        <button className="flex-inline justify-center items-center flex-row bg-gray-800 text-gray-100 px-4 py-2 rounded-md"
+                            onClick={handleRestart}
+                        >
+                            <RotateCcw className="inline" size={14} /> Restart
+                        </button>
+                        <div className="text-lg mt-7 font-extrabold">
+                            <span className="text-green-500">{results.right} right</span>, <span className="text-red-400">{results.wrong} wrong</span>
+                        </div>
+                    </div>
+                }
+            </div>
+            <div className="row-start-7 text-center flex justify-center gap-6  [&_button]:rounded-md">
+                {(!showBack && cardIndex < loaderData.deck.cards.length) && <button onClick={() => setShowBack(true)} className="self-center p-3 bg-gray-100">Show answer</button>}
+                {(showBack && cardIndex < loaderData.deck.cards.length) &&
+                    <div className="flex gap-16 items-center [&_button]:py-3 [&_button]:px-6">
+
+                        <button onClick={() => {
+                            setShowBack(i => !i);
+                            setResults(i => ({
+                                ...i,
+                                wrong: i.wrong + 1,
+                                wrongIndexes: [...i.wrongIndexes, cardIndex]
+                            }));
+                            setCardIndex(i => Math.min(i + 1, loaderData.deck.cards.length));
+                        }} className="bg-gray-900 text-gray-200">Wrong</button>
+
+                        <button onClick={() => {
+                            setShowBack(i => !i);
+                            setResults(i => ({
+                                ...i,
+                                right: i.right + 1
+                            }));
+                            setCardIndex(i => Math.min(i + 1, loaderData.deck.cards.length));
+                        }} className="bg-gray-100 text-gray-950">Right</button>
+
+                    </div>
+                }
+                {
+
+                }
+            </div>
+        </div>
+    );
+};

--- a/app/styles/atom-one-light.css
+++ b/app/styles/atom-one-light.css
@@ -1,0 +1,94 @@
+/*
+
+Atom One Light by Daniel Gamage
+Original One Light Syntax theme from https://github.com/atom/one-light-syntax
+
+base:    #fafafa
+mono-1:  #383a42
+mono-2:  #686b77
+mono-3:  #a0a1a7
+hue-1:   #0184bb
+hue-2:   #4078f2
+hue-3:   #a626a4
+hue-4:   #50a14f
+hue-5:   #e45649
+hue-5-2: #c91243
+hue-6:   #986801
+hue-6-2: #c18401
+
+*/
+
+.hljs {
+  color: #383a42;
+  background: #fafafa;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #a0a1a7;
+  font-style: italic;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula {
+  color: #a626a4;
+}
+
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-deletion,
+.hljs-subst {
+  color: #e45649;
+}
+
+.hljs-literal {
+  color: #0184bb;
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-addition,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #50a14f;
+}
+
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #986801;
+}
+
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #4078f2;
+}
+
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #c18401;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-link {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Implement full-stack support for studying decks, including persistence for study sessions and deck metadata using Cloudflare D1.

- Set up D1 database schema for decks and study sessions
- Create study session API endpoints for history and result tracking
- Implement frontend study route with flashcard logic and scoring
- Add a comprehensive decks list page with search and performance stats
- Update code highlighting theme to atom-one-light across the app
- Improve temporal utility functions for better "time ago" display
- Add loading animations and UI refinements to the generation flow

Closes #11